### PR TITLE
Patch 9 11

### DIFF
--- a/src/data/summary.js
+++ b/src/data/summary.js
@@ -1,5 +1,5 @@
 export const summary = {
-  "9.10":
+  "9.11":
     {
       "top_champions": {
         "top":["Aatrox", "Jax", "Nasus", "Urgot", "Yorick"],

--- a/src/data/summary.js
+++ b/src/data/summary.js
@@ -2,24 +2,23 @@ export const summary = {
   "9.10":
     {
       "top_champions": {
-        "top":["Jax", "Renekton", "Riven"],
-        "jg":["Sejuani", "Nunu", "RekSai"],
-        "mid":["Ahri", "Talon", "Kassadin"],
-        "adc": ["Kaisa", "Jinx", "Sivir"],
-        "sup": ["Thresh", "Nautilus", "Pyke"]
+        "top":["Aatrox", "Jax", "Nasus", "Urgot", "Yorick"],
+        "jg":["Hecarim", "Nunu", "Amumu","Jax","Rammus"],
+        "mid":["Ahri", "Morgana", "Kassadin", "Aatrox", "Zed"],
+        "adc": ["Kaisa", "Jinx", "Sivir", "Draven", "Ezreal"],
+        "sup": ["Thresh", "Nautilus", "Pyke", "Morgana", "Nami"]
       },
       "buffs": [
-        "Más daño para Urbot",
-        "1.3x mejora de Gonzus con Ezreal"
+        "Yuumi fixes",
+        "Warwick Q healing increased"
       ],
       "nerfs": [
-        "50% menos de daño para el Gonzus",
-        "20% mas de mala leche",
-        "1.5x trolls por partida"
+        "Akali passive damage heavily nerfed",
+        "Galio W scaling damage nerfed"
       ],
       "updates": [
-        "El scattle es menos poronga",
-        "Tu prima"
+        "Zac R update (reverted to pre-patch 7.9)",
+        "Janna W damage lowered, cooldown lowered. E new passive: Each ability that slows or knocks back an enemy champion reduces E cooldown by 20%"
       ],
     }
   }


### PR DESCRIPTION
Patch 9.11

"top_champions": {
        "top":["Aatrox", "Jax", "Nasus", "Urgot", "Yorick"],
        "jg":["Hecarim", "Nunu", "Amumu","Jax","Rammus"],
        "mid":["Ahri", "Morgana", "Kassadin", "Aatrox", "Zed"],
        "adc": ["Kaisa", "Jinx", "Sivir", "Draven", "Ezreal"],
        "sup": ["Thresh", "Nautilus", "Pyke", "Morgana", "Nami"]
      },
      "buffs": [
        "Yuumi fixes",
        "Warwick Q healing increased"
      ],
      "nerfs": [
        "Akali passive damage heavily nerfed",
        "Galio W scaling damage nerfed"
      ],
      "updates": [
        "Zac R update (reverted to pre-patch 7.9)",
        "Janna W damage lowered, cooldown lowered. E new passive: Each ability that slows or knocks back an enemy champion reduces E cooldown by 20%"