### PR TITLE
patch notes 9.11 corrections

### DIFF
--- a/src/data/summary.js
+++ b/src/data/summary.js
@@ -9,16 +9,18 @@ export const summary = {
         "sup": ["Thresh", "Nautilus", "Pyke", "Morgana", "Nami"]
       },
       "buffs": [
-        "Yuumi fixes",
         "Warwick Q healing increased"
       ],
       "nerfs": [
-        "Akali passive damage heavily nerfed",
-        "Galio W scaling damage nerfed"
+        "Akali passive damage heavily nerfed. Energy refund nerf",
+        "Galio W base damage nerfed, scaling buffed. E base damage nerf",
+        "Amumu passive damage nerfed",
+        "Jayce Q damage heavily nerfed"
       ],
       "updates": [
         "Zac R update (reverted to pre-patch 7.9)",
-        "Janna W damage lowered, cooldown lowered. E new passive: Each ability that slows or knocks back an enemy champion reduces E cooldown by 20%"
+        "Janna W damage lowered, cooldown lowered. E new passive: Each ability that slows or knocks back an enemy champion reduces E cooldown by 20%",
+        "Several Yuumi bugfixes"
       ],
     }
   }


### PR DESCRIPTION
export const summary = {
  "9.11":
    {
      "top_champions": {
        "top":["Aatrox", "Jax", "Nasus", "Urgot", "Yorick"],
        "jg":["Hecarim", "Nunu", "Amumu","Jax","Rammus"],
        "mid":["Ahri", "Morgana", "Kassadin", "Aatrox", "Zed"],
        "adc": ["Kaisa", "Jinx", "Sivir", "Draven", "Ezreal"],
        "sup": ["Thresh", "Nautilus", "Pyke", "Morgana", "Nami"]
      },
      "buffs": [
        "Warwick Q healing increased"
      ],
      "nerfs": [
        "Akali passive damage heavily nerfed. Energy refund nerf",
        "Galio W base damage nerfed, scaling buffed. E base damage nerf",
        "Amumu passive damage nerfed",
        "Jayce Q damage heavily nerfed"
      ],
      "updates": [
        "Zac R update (reverted to pre-patch 7.9)",
        "Janna W damage lowered, cooldown lowered. E new passive: Each ability that slows or knocks back an enemy champion reduces E cooldown by 20%",
        "Several Yuumi bugfixes"
      ],
    }
  }
